### PR TITLE
Fixing hard crash when DinkC script divides by zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# metadata in root folder
+.vs/
+.idea/
+
+# metadata in solution folder
+windows_vs2017/.vs/
+windows_vs2017/.idea/
+
+# object files
+windows_vs2017/Win32/
+windows_vs2017/x64/
+
+# binaries
+bin/
+
+# baked proton textures
+*.rttex
+*.rtfont
+
+# other VS metadata?
+*.aps
+*.sdf
+*.VC.db
+*.VC.opendb
+*.user

--- a/source/dink/dink.cpp
+++ b/source/dink/dink.cpp
@@ -4890,7 +4890,16 @@ next2:
 		g_dglos.g_playerInfo.var[i].var -= newval;
 
 	if (math == '/')
-		g_dglos.g_playerInfo.var[i].var = g_dglos.g_playerInfo.var[i].var / newval;
+	{
+	    if (newval != 0)
+	    {
+	        g_dglos.g_playerInfo.var[i].var = g_dglos.g_playerInfo.var[i].var / newval;
+	    } else
+	    {
+	        
+	        LogMsg("ERROR (var equals): Variable division by 0, ignoring operation! Script name: %s, script position: %d", g_scriptInstance[script]->name, g_scriptInstance[script]->current);
+	    }
+	}
 
 	if (math == '*')
 		g_dglos.g_playerInfo.var[i].var = g_dglos.g_playerInfo.var[i].var * newval;
@@ -10940,7 +10949,14 @@ LogMsg("%d scripts used", g_dglos.g_returnint);
 			int32 p[20] = {1,1,0,0,0,0,0,0,0,0};  
 			if (get_parms(ev[1], script, h, p))
 			{
-				g_dglos.g_returnint = (g_nlist[0] % g_nlist[1]);
+			    if (g_nlist[1] != 0)
+			    {
+			        g_dglos.g_returnint = (g_nlist[0] % g_nlist[1]);
+			    } else
+			    {
+			        LogMsg("ERROR (var equals): Variable division by 0, ignoring operation! Script name: %s, script position: %d", g_scriptInstance[script]->name, g_scriptInstance[script]->current);
+			        g_dglos.g_returnint = g_nlist[0];
+			    }
 			}
 			strcpy_safe(pLineIn, h);  
 			ugly_return(0);


### PR DESCRIPTION
Instead of hard crashing, a log error entry is made when a script attempts to divide a variable by 0 or call modulo function with 0

I think this is a preferable way for the game to behave, although perhaps logging the error AND hard crashing might be preferable in order to force the DMOD author to fix the issue in their scripts?... On the other hand, many DMOD authors are not around, and hard crashes are just frustrating for the player. Continuing the script (even if in a possibly unintended way) is probably preferable...