### PR TITLE
Fix MIDI playback in Flatpak by building SDL2_mixer with FluidSynth

### DIFF
--- a/flatpak/com.rtsoft.DinkSmallwoodHD.json
+++ b/flatpak/com.rtsoft.DinkSmallwoodHD.json
@@ -10,9 +10,54 @@
     "--socket=wayland",
     "--socket=pulseaudio",
     "--device=dri",
-    "--share=network"
+    "--share=network",
+    "--filesystem=xdg-run/pipewire-0:ro"
   ],
   "modules": [
+    {
+      "name": "fluidsynth",
+      "buildsystem": "cmake-ninja",
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DLIB_SUFFIX=",
+        "-Denable-libsndfile=OFF",
+        "-Denable-dbus=OFF",
+        "-Denable-ipv6=OFF",
+        "-Denable-network=OFF",
+        "-Denable-oss=OFF",
+        "-Denable-midishare=OFF",
+        "-Denable-readline=OFF",
+        "-Denable-ladspa=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/FluidSynth/fluidsynth/archive/v2.3.4.tar.gz",
+          "sha256": "1529ef5bc3b9ef3adc2a7964505912f7305103e269e50cc0316f500b22053ac9"
+        }
+      ]
+    },
+
+    {
+      "name": "SDL2_mixer",
+      "buildsystem": "cmake-ninja",
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DSDL2MIXER_FLUIDSYNTH=ON",
+        "-DSDL2MIXER_MIDI=ON",
+        "-DSDL2MIXER_OPUS=OFF",
+        "-DSDL2MIXER_MOD=OFF",
+        "-DSDL2MIXER_FLAC=OFF",
+        "-DSDL2MIXER_MP3=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.0/SDL2_mixer-2.8.0.tar.gz",
+          "sha256": "1cfb34c87b26dbdbc7afd68c4f545c0116ab5f90bbfecc5aebe2a9e4e3a5b5e8"
+        }
+      ]
+    },
     {
       "name": "dink-smallwood-hd",
       "buildsystem": "cmake-ninja",

--- a/flatpak/dink-smallwood-hd.sh
+++ b/flatpak/dink-smallwood-hd.sh
@@ -35,5 +35,13 @@ if [ ! -e "$DATA_DIR/RTDinkApp" ]; then
     ln -sf "/app/bin/RTDinkApp" "$DATA_DIR/RTDinkApp"
 fi
 
+# Set SDL_SOUNDFONTS to use system soundfont or fallback to FluidSynth default
+# SDL_mixer with FluidSynth will use this to synthesize MIDI
+if [ -f "/usr/share/sounds/sf2/FluidR3_GM.sf2" ]; then
+    export SDL_SOUNDFONTS="/usr/share/sounds/sf2/FluidR3_GM.sf2"
+elif [ -f "/usr/share/soundfonts/default.sf2" ]; then
+    export SDL_SOUNDFONTS="/usr/share/soundfonts/default.sf2"
+fi
+
 cd "$DATA_DIR"
 exec ./RTDinkApp "$@"


### PR DESCRIPTION
The game uses SDL_mixer on Linux (not FMOD), which requires a system MIDI synthesizer to play MIDI files.

Changes:
- Build SDL2_mixer with FluidSynth support enabled
- Configure FluidSynth with minimal dependencies for smaller size
- Set SDL_SOUNDFONTS environment variable to use system soundfonts
- Add PipeWire filesystem access for better audio routing

Technical details:
- On Linux, RTDink uses AudioManagerSDL which wraps SDL2_mixer
- SDL_mixer's Mix_LoadMUS() needs FluidSynth to synthesize MIDI
- The SetDLS() call in App.cpp is a no-op on Linux (FMOD-only)
- FluidSynth will use system soundfonts via SDL_SOUNDFONTS env var

Resolves forum report: no MIDI output on AMD64 CachyOS system